### PR TITLE
Inline favicon using data URI

### DIFF
--- a/frontend/public/index-improved.html
+++ b/frontend/public/index-improved.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Keyword Research Tool</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%234F46E5'/%3E%3Ctext x='50%25' y='50%25' dy='.35em' text-anchor='middle' font-family='Inter' font-size='36' fill='white'%3EK%3C/text%3E%3C/svg%3E"
+  >
   <style>
     * {
       margin: 0;

--- a/frontend/public/index-simple.html
+++ b/frontend/public/index-simple.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Keyword Research Tool</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%234F46E5'/%3E%3Ctext x='50%25' y='50%25' dy='.35em' text-anchor='middle' font-family='Inter' font-size='36' fill='white'%3EK%3C/text%3E%3C/svg%3E"
+  >
   <style>
     * {
       margin: 0;

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Keyword Research Tool</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%234F46E5'/%3E%3Ctext x='50%25' y='50%25' dy='.35em' text-anchor='middle' font-family='Inter' font-size='36' fill='white'%3EK%3C/text%3E%3C/svg%3E"
+  >
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
## Summary
- remove the standalone favicon asset
- embed a branded SVG favicon via data URI from each HTML entry point so it renders without requiring a separate file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e533945ec083329015aaac6e4cd944