### PR TITLE
Add crawl configuration controls to frontend forms

### DIFF
--- a/frontend/public/app-improved.js
+++ b/frontend/public/app-improved.js
@@ -8,6 +8,8 @@ const elements = {
   countrySelect: document.getElementById('countrySelect'),
   languageSelect: document.getElementById('languageSelect'),
   startBtn: document.getElementById('startBtn'),
+  maxPagesInput: document.getElementById('maxPagesInput'),
+  followLinksCheckbox: document.getElementById('followLinksCheckbox'),
   progressContainer: document.getElementById('progressContainer'),
   progressFill: document.getElementById('progressFill'),
   progressText: document.getElementById('progressText'),
@@ -26,11 +28,33 @@ function getSelectedLanguageLabel() {
   return option?.dataset?.label || option?.textContent || '';
 }
 
+function getCrawlOptions() {
+  const options = {};
+
+  if (elements.maxPagesInput) {
+    const parsed = parseInt(elements.maxPagesInput.value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      const clamped = Math.min(parsed, 100);
+      options.maxPages = clamped;
+      if (clamped !== parsed) {
+        elements.maxPagesInput.value = clamped;
+      }
+    }
+  }
+
+  if (elements.followLinksCheckbox) {
+    options.followLinks = elements.followLinksCheckbox.checked;
+  }
+
+  return options;
+}
+
 async function startResearch() {
   const url = elements.urlInput.value.trim();
   const country = elements.countrySelect.value;
   const language = elements.languageSelect.value;
   const languageLabel = getSelectedLanguageLabel();
+  const options = getCrawlOptions();
 
   if (!url) {
     showError('Please enter a website URL');
@@ -49,7 +73,7 @@ async function startResearch() {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ url, country, language, languageLabel }),
+      body: JSON.stringify({ url, country, language, languageLabel, options }),
     });
 
     if (!response.ok) {

--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -2,6 +2,29 @@ const API_URL = 'http://localhost:3000/api';
 
 let currentJobId = null;
 
+function getCrawlOptions() {
+  const options = {};
+
+  const maxPagesInput = document.getElementById('maxPagesInput');
+  if (maxPagesInput) {
+    const parsed = parseInt(maxPagesInput.value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      const clamped = Math.min(parsed, 100);
+      options.maxPages = clamped;
+      if (clamped !== parsed) {
+        maxPagesInput.value = clamped;
+      }
+    }
+  }
+
+  const followLinksCheckbox = document.getElementById('followLinksCheckbox');
+  if (followLinksCheckbox) {
+    options.followLinks = followLinksCheckbox.checked;
+  }
+
+  return options;
+}
+
 // Wait for DOM to be ready
 document.addEventListener('DOMContentLoaded', () => {
   const startBtn = document.getElementById('startBtn');
@@ -25,6 +48,7 @@ async function startResearch() {
   const languageSelect = document.getElementById('languageSelect');
   const language = languageSelect.value;
   const languageLabel = languageSelect.options[languageSelect.selectedIndex]?.dataset?.label || '';
+  const options = getCrawlOptions();
 
   if (!url) {
     showError('Please enter a URL');
@@ -39,7 +63,7 @@ async function startResearch() {
 
   try {
     // Start research job
-    const payload = { url, country, language, languageLabel };
+    const payload = { url, country, language, languageLabel, options };
 
     const response = await fetch(`${API_URL}/research`, {
       method: 'POST',

--- a/frontend/public/index-improved.html
+++ b/frontend/public/index-improved.html
@@ -72,6 +72,66 @@
       border-color: #667eea;
     }
 
+    .crawl-options {
+      background: #f5f7ff;
+      border: 1px solid #d9defa;
+      border-radius: 10px;
+      padding: 20px;
+      margin-bottom: 20px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .crawl-options h3 {
+      font-size: 1.1rem;
+      color: #4f46e5;
+    }
+
+    .crawl-options .option-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .crawl-options label {
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .crawl-options input[type='number'] {
+      width: 120px;
+      padding: 10px 12px;
+      border: 2px solid #e0e0e0;
+      border-radius: 8px;
+      font-size: 1rem;
+    }
+
+    .crawl-options input[type='number']:focus {
+      outline: none;
+      border-color: #667eea;
+    }
+
+    .crawl-options .checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .crawl-options input[type='checkbox'] {
+      width: 18px;
+      height: 18px;
+      accent-color: #667eea;
+    }
+
+    .crawl-options .helper-text {
+      font-size: 0.85rem;
+      color: #6b7280;
+      line-height: 1.4;
+    }
+
     .btn {
       padding: 15px 30px;
       background: #667eea;
@@ -349,6 +409,27 @@
           <option value="zh" data-label="中文">🇨🇳 中文</option>
         </select>
         <button class="btn" id="startBtn">Start Research</button>
+      </div>
+
+      <div class="crawl-options">
+        <h3>Website crawl settings</h3>
+        <div class="option-row">
+          <label for="maxPagesInput">Max pages to crawl</label>
+          <input
+            type="number"
+            id="maxPagesInput"
+            min="1"
+            max="100"
+            value="20"
+          />
+        </div>
+        <label class="checkbox-row" for="followLinksCheckbox">
+          <input type="checkbox" id="followLinksCheckbox" checked />
+          <span>Follow internal links from the homepage</span>
+        </label>
+        <p class="helper-text">
+          Control how deep the crawler explores your site. Lower values run faster while higher values capture more context.
+        </p>
       </div>
 
       <div class="progress-container" id="progressContainer">

--- a/frontend/public/index-simple.html
+++ b/frontend/public/index-simple.html
@@ -111,6 +111,66 @@
       border-color: #667eea;
     }
 
+    .crawl-options {
+      background: #f5f7ff;
+      border: 1px solid #d9defa;
+      border-radius: 10px;
+      padding: 20px;
+      margin-bottom: 20px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .crawl-options h3 {
+      font-size: 1.1rem;
+      color: #4f46e5;
+    }
+
+    .crawl-options .option-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .crawl-options label {
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .crawl-options input[type='number'] {
+      width: 120px;
+      padding: 10px 12px;
+      border: 2px solid #e0e0e0;
+      border-radius: 8px;
+      font-size: 1rem;
+    }
+
+    .crawl-options input[type='number']:focus {
+      outline: none;
+      border-color: #667eea;
+    }
+
+    .crawl-options .checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .crawl-options input[type='checkbox'] {
+      width: 18px;
+      height: 18px;
+      accent-color: #667eea;
+    }
+
+    .crawl-options .helper-text {
+      font-size: 0.85rem;
+      color: #6b7280;
+      line-height: 1.4;
+    }
+
     select {
       padding: 15px;
       border: 2px solid #e0e0e0;
@@ -312,6 +372,27 @@
           <option value="pt" data-label="Português">Português</option>
         </select>
         <button class="btn" id="startBtn">Start Research</button>
+      </div>
+
+      <div class="crawl-options">
+        <h3>Website crawl settings</h3>
+        <div class="option-row">
+          <label for="maxPagesInput">Max pages to crawl</label>
+          <input
+            type="number"
+            id="maxPagesInput"
+            min="1"
+            max="100"
+            value="20"
+          />
+        </div>
+        <label class="checkbox-row" for="followLinksCheckbox">
+          <input type="checkbox" id="followLinksCheckbox" checked />
+          <span>Follow internal links from the homepage</span>
+        </label>
+        <p class="helper-text">
+          Control how deep the crawler explores your site. Lower values run faster while higher values capture more context.
+        </p>
       </div>
 
       <div class="progress-container" id="progressContainer">


### PR DESCRIPTION
## Summary
- add crawl settings controls to the simple and improved frontends so users can choose crawl depth and internal link following
- send the selected crawl options with research requests so the backend honors the configured crawl depth

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e5f5da69fc8332b929173e7bd92a38