### PR TITLE
chore: upgrade gemini model to 2.5 flash

### DIFF
--- a/GEMINI-INTEGRATION.md
+++ b/GEMINI-INTEGRATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The keyword research tool now uses **Google Gemini 2.0 Flash** to enhance clustering and provide intelligent topic analysis.
+The keyword research tool now uses **Google Gemini 2.5 Flash** to enhance clustering and provide intelligent topic analysis.
 
 ## Features Added
 
@@ -147,7 +147,7 @@ const clusters = await clustering.clusterKeywords(keywordData, websiteContext);
 ### Gemini API Pricing (Free Tier)
 
 - **Free quota**: 15 requests/minute, 1,500 requests/day
-- **Model**: gemini-2.0-flash-exp (experimental, free)
+- **Model**: gemini-2.5-flash (general availability, fast)
 - **Cost**: $0 for basic usage
 
 ### Typical Usage Per Research
@@ -210,7 +210,7 @@ Target audience: Business owners and marketing managers
 
 ```bash
 # Test your API key
-curl https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent?key=YOUR_API_KEY \
+curl https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=YOUR_API_KEY \
   -H 'Content-Type: application/json' \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```
@@ -255,7 +255,7 @@ Planned features:
 GEMINI_API_KEY=your_key_here
 
 # Optional: Configure which model to use
-GEMINI_MODEL=gemini-2.0-flash-exp  # Default
+GEMINI_MODEL=gemini-2.5-flash  # Default
 
 # Optional: Number of clusters to enhance
 GEMINI_ENHANCE_LIMIT=5  # Default

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An intelligent keyword research tool that combines web scraping, AI-powered keyw
 
 ## ✨ Features
 
-- **🤖 AI-Powered Keyword Extraction** - Uses Gemini 2.0 to think like a marketer and identify business-relevant keywords
+- **🤖 AI-Powered Keyword Extraction** - Uses Gemini 2.5 to think like a marketer and identify business-relevant keywords
 - **🌍 Multi-Country Support** - Get accurate search volumes for 11 countries (Switzerland, Germany, Austria, France, Italy, UK, US, Canada, Netherlands, Belgium, Spain)
 - **🗣️ Multi-Language Support** - Extract keywords in 11 languages (English, German, French, Italian, Spanish, Dutch, Portuguese, Polish, Russian, Japanese, Chinese)
 - **📊 Real Google Ads Data** - Direct integration with Google Ads Keyword Planner API for accurate search volumes, CPC, and competition data

--- a/backend/services/gemini.js
+++ b/backend/services/gemini.js
@@ -63,7 +63,7 @@ async function extractKeywordsWithAI(scrapedContent, maxKeywords = 150, language
     const ai = initializeGemini();
     if (!ai) return null; // Will fall back to traditional extraction
 
-    const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+    const model = ai.getGenerativeModel({ model: 'gemini-2.5-flash' });
 
     const { displayName: targetLanguage, primary: primaryLanguage } = buildLanguageContext(languageCode);
 
@@ -130,7 +130,7 @@ async function enhanceClusterWithAI(cluster, websiteContext, languageCode = 'en'
     const ai = initializeGemini();
     if (!ai) return cluster; // Return unchanged if no API key
 
-    const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+    const model = ai.getGenerativeModel({ model: 'gemini-2.5-flash' });
 
     const { displayName: languageName, primary: primaryLanguage } = buildLanguageContext(languageCode);
 
@@ -199,7 +199,7 @@ async function analyzeAndRegroupClusters(clusters, websiteContext, allKeywords, 
     const ai = initializeGemini();
     if (!ai) return clusters; // Return unchanged if no API key
 
-    const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+    const model = ai.getGenerativeModel({ model: 'gemini-2.5-flash' });
 
     const { displayName: languageName, primary: primaryLanguage } = buildLanguageContext(languageCode);
 
@@ -284,7 +284,7 @@ async function scrutinizeClusterTopics(clusters, allKeywords = [], websiteContex
       return clusters;
     }
 
-    const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+    const model = ai.getGenerativeModel({ model: 'gemini-2.5-flash' });
     const { displayName: languageName, primary: primaryLanguage } = buildLanguageContext(languageInput);
 
     const duplicateHints = buildDuplicateHints(clusters);
@@ -424,7 +424,7 @@ async function generateContentBrief(cluster, websiteContext, languageCode = 'en'
     const ai = initializeGemini();
     if (!ai) return null;
 
-    const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+    const model = ai.getGenerativeModel({ model: 'gemini-2.5-flash' });
 
     const { displayName: languageName, primary: primaryLanguage } = buildLanguageContext(languageCode);
 


### PR DESCRIPTION
## Summary
- update the Gemini service to use the gemini-2.5-flash model for all AI-powered workflows
- refresh the integration guide and README to reference the newer model details

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68eb8c0f17a083328c481428301727ab