### PR TITLE
Improve cross-platform scraping launch configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,29 @@ An intelligent keyword research tool that combines web scraping, AI-powered keyw
 
    ```bash
    cd python-ads-service
-   PYTHON_SERVICE_PORT=5001 python3 app.py
    ```
+
+   - **macOS / Linux**
+
+     ```bash
+     PYTHON_SERVICE_PORT=5001 python3 app.py
+     ```
+
+   - **Windows PowerShell**
+
+     ```powershell
+     $env:PYTHON_SERVICE_PORT=5001
+     python app.py
+     ```
+
+   - **Windows Command Prompt**
+
+     ```cmd
+     set PYTHON_SERVICE_PORT=5001
+     python app.py
+     ```
+
+   > 💡 Windows users with multiple Python installations can also run `py -3 app.py` after setting the environment variable in the same terminal.
 
    **Terminal 2 – Node.js server (port 3000)**
 

--- a/backend/services/scraper-unified.js
+++ b/backend/services/scraper-unified.js
@@ -98,16 +98,7 @@ async function scrapeWithPlaywright(url, options = {}) {
     // Launch browser with optimized settings
     const launchOptions = {
       headless: true,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-        '--disable-accelerated-2d-canvas',
-        '--no-first-run',
-        '--no-zygote',
-        '--single-process', // Might be useful for some environments
-        '--disable-gpu'
-      ],
+      args: buildChromiumLaunchArgs(),
     };
 
     // Use custom Chrome executable if path is provided in .env
@@ -465,6 +456,26 @@ async function validateUrl(url) {
   } catch (error) {
     return false;
   }
+}
+
+/**
+ * Playwright launch arguments tuned for each platform.
+ * Linux still needs the sandbox flags, but Windows and macOS fail to boot
+ * when `--single-process`/`--no-zygote` are forced.
+ */
+function buildChromiumLaunchArgs() {
+  const args = [
+    '--disable-dev-shm-usage',
+    '--disable-accelerated-2d-canvas',
+    '--no-first-run',
+    '--disable-gpu',
+  ];
+
+  if (process.platform === 'linux') {
+    args.push('--no-sandbox', '--disable-setuid-sandbox', '--no-zygote', '--single-process');
+  }
+
+  return args;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- adjust the Playwright launch configuration to use platform-aware Chromium flags so Windows and macOS runs no longer fail to boot the browser
- update the README with Windows-specific commands for launching the Python microservice alongside the existing macOS/Linux instructions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ebaa580eb883328c26e42901466896